### PR TITLE
Slightly slowed Omnibox animations and hide/show behaviour corrected

### DIFF
--- a/app/src/main/java/io/github/UltimateBrowserProject/Activity/BrowserActivity.java
+++ b/app/src/main/java/io/github/UltimateBrowserProject/Activity/BrowserActivity.java
@@ -16,6 +16,7 @@ import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.Build;
@@ -330,7 +331,6 @@ public class BrowserActivity extends Activity implements BrowserController {
                 if (gridView.isEditMode()) {
                     gridView.stopEditMode();
                     relayoutOK.setVisibility(View.GONE);
-                    omnibox.setVisibility(View.VISIBLE);
                     initHomeGrid(layout, true);
                 }
             }
@@ -398,7 +398,6 @@ public class BrowserActivity extends Activity implements BrowserController {
             UltimateBrowserProjectRelativeLayout layout = (UltimateBrowserProjectRelativeLayout) currentAlbumController;
             if (layout.getFlag() == BrowserUnit.FLAG_HOME) {
                 initHomeGrid(layout, true);
-                omnibox.setVisibility(View.VISIBLE);
             }
         }
     }
@@ -589,7 +588,6 @@ public class BrowserActivity extends Activity implements BrowserController {
                     final UltimateBrowserProjectRelativeLayout layout = (UltimateBrowserProjectRelativeLayout) currentAlbumController;
                     if (layout.getFlag() == BrowserUnit.FLAG_HOME) {
                         initHomeGrid(layout, true);
-                        omnibox.setVisibility(View.VISIBLE);
                         return;
                     }
                     initBHList(layout, true);
@@ -621,7 +619,6 @@ public class BrowserActivity extends Activity implements BrowserController {
                         final UltimateBrowserProjectRelativeLayout layout = (UltimateBrowserProjectRelativeLayout) currentAlbumController;
                         if (layout.getFlag() == BrowserUnit.FLAG_HOME) {
                             initHomeGrid(layout, true);
-                            omnibox.setVisibility(View.VISIBLE);
                             return;
                         }
                         initBHList(layout, true);
@@ -688,6 +685,12 @@ public class BrowserActivity extends Activity implements BrowserController {
     private void initHomeGrid(final UltimateBrowserProjectRelativeLayout layout, boolean update) {
         if (update) {
             updateProgress(BrowserUnit.PROGRESS_MIN);
+        }
+
+        if(omnibox != null) {
+            omnibox.setVisibility(View.VISIBLE);
+        } else {
+            initOmnibox();
         }
 
         RecordAction action = new RecordAction(this);
@@ -898,7 +901,6 @@ public class BrowserActivity extends Activity implements BrowserController {
             layout.setAlbumTitle(getString(R.string.album_title_home));
             holder = layout;
             initHomeGrid(layout, true);
-            omnibox.setVisibility(View.VISIBLE);
         } else {
             return;
         }
@@ -1124,7 +1126,6 @@ public class BrowserActivity extends Activity implements BrowserController {
         layout.setAlbumCover(ViewUnit.capture(layout, dimen144dp, dimen108dp, false, Bitmap.Config.RGB_565));
         layout.setAlbumTitle(getString(R.string.album_title_home));
         initHomeGrid(layout, true);
-        omnibox.setVisibility(View.VISIBLE);
 
         int index = switcherContainer.indexOfChild(currentAlbumController.getAlbumView());
         currentAlbumController.deactivate();

--- a/app/src/main/java/io/github/UltimateBrowserProject/View/UltimateBrowserProjectWebView.java
+++ b/app/src/main/java/io/github/UltimateBrowserProject/View/UltimateBrowserProjectWebView.java
@@ -136,11 +136,11 @@ public class UltimateBrowserProjectWebView extends WebView implements AlbumContr
 
         anchor = Integer.valueOf(sp.getString(context.getString(R.string.sp_anchor), "1"));
         if (anchor == 0) {
-            UP_SCROLL_THRESHOLD = convertDpToPixels(100);
+            UP_SCROLL_THRESHOLD = convertDpToPixels(20);
             DOWN_SCROLL_THRESHOLD = convertDpToPixels(1);
         } else {
             UP_SCROLL_THRESHOLD = convertDpToPixels(1);
-            DOWN_SCROLL_THRESHOLD = convertDpToPixels(100);
+            DOWN_SCROLL_THRESHOLD = convertDpToPixels(20);
         }
 
         setOnTouchListener(new OnTouchListener() {
@@ -157,17 +157,19 @@ public class UltimateBrowserProjectWebView extends WebView implements AlbumContr
                     y2 = y1;
                 } else if (action == MotionEvent.ACTION_UP) {
                     if ((y1 - y2) > UP_SCROLL_THRESHOLD) {
-                        if (anchor == 0) {
+                        /*if (anchor == 0) {
                             browserController.showOmnibox();
                         } else {
                             browserController.hideOmnibox();
-                        }
+                        }*/
+                        browserController.showOmnibox();
                     } else if ((y1 - y2) < -DOWN_SCROLL_THRESHOLD) {
-                        if (anchor == 0) {
+                        /*if (anchor == 0) {
                             browserController.hideOmnibox();
                         } else {
                             browserController.showOmnibox();
-                        }
+                        }*/
+                        browserController.hideOmnibox();
                     }
                     y2 = 0;
                 }

--- a/app/src/main/res/anim/slide_bottom_down.xml
+++ b/app/src/main/res/anim/slide_bottom_down.xml
@@ -3,12 +3,12 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:shareInterpolator="false">
     <translate xmlns:android="http://schemas.android.com/apk/res/android"
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromYDelta="0"
         android:interpolator="@android:anim/accelerate_interpolator"
         android:toYDelta="100%p" />
     <alpha
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromAlpha="1.0"
         android:interpolator="@android:anim/accelerate_interpolator"
         android:toAlpha="0.0" />

--- a/app/src/main/res/anim/slide_bottom_up.xml
+++ b/app/src/main/res/anim/slide_bottom_up.xml
@@ -3,12 +3,12 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:shareInterpolator="false">
     <translate xmlns:android="http://schemas.android.com/apk/res/android"
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromYDelta="100%p"
         android:interpolator="@android:anim/decelerate_interpolator"
         android:toYDelta="0" />
     <alpha
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromAlpha="0.0"
         android:interpolator="@android:anim/accelerate_interpolator"
         android:toAlpha="1.0" />

--- a/app/src/main/res/anim/slide_top_down.xml
+++ b/app/src/main/res/anim/slide_top_down.xml
@@ -3,12 +3,12 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:shareInterpolator="false">
     <translate
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromYDelta="-100%"
         android:interpolator="@android:anim/decelerate_interpolator"
         android:toYDelta="0" />
     <alpha
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromAlpha="0.0"
         android:interpolator="@android:anim/decelerate_interpolator"
         android:toAlpha="1.0" />

--- a/app/src/main/res/anim/slide_top_up.xml
+++ b/app/src/main/res/anim/slide_top_up.xml
@@ -3,12 +3,12 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:shareInterpolator="false">
     <translate
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromYDelta="0"
         android:interpolator="@android:anim/accelerate_interpolator"
         android:toYDelta="-100%" />
     <alpha
-        android:duration="@android:integer/config_shortAnimTime"
+        android:duration="@android:integer/config_mediumAnimTime"
         android:fromAlpha="1.0"
         android:interpolator="@android:anim/accelerate_interpolator"
         android:toAlpha="0.0" />


### PR DESCRIPTION
I think that changing animation from short to medium (200ms of difference) would be nicer. I've tested myself and it feels smoother.
I've also commented some code on show/hide Omnibox, because I guess everyone would expect it to hide whenever there's a scrolldown action. The fact that the Omni is on bottom shouldn't mean that the behaviour has to be inverted.
