### PR TITLE
Revert "Grammatical English Fix"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,7 +169,7 @@
         DuckDuckGo
     </string>
     <string name="setting_summary_search_engine_startpage">
-        Start Page
+        StartPage
     </string>
     <string name="setting_summary_search_engine_bing">
         Bing


### PR DESCRIPTION
Reverts Thunderbottom/UltimateBrowserProject#72

(StartPage was correct, it's the name of a search engine)
